### PR TITLE
Added -no-interpolation option to KLEE

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -219,11 +219,9 @@ namespace {
   NamedSeedMatching("named-seed-matching",
                     cl::desc("Use names to match symbolic objects to inputs."));
 
-#ifdef SUPPORT_Z3
   cl::opt<bool>
   NoInterpolation("no-interpolation",
                   cl::desc("Disable interpolation for search space reduction"));
-#endif
 
   cl::opt<double>
   MaxStaticForkPct("max-static-fork-pct", cl::init(1.));

--- a/test/Feature/DanglingConcreteReadExpr.c
+++ b/test/Feature/DanglingConcreteReadExpr.c
@@ -1,6 +1,6 @@
 // RUN: %llvmgcc %s -emit-llvm -O0 -c -o %t1.bc
 // RUN: rm -rf %t.klee-out
-// RUN: %klee --optimize=false --output-dir=%t.klee-out %t1.bc
+// RUN: %klee --optimize=false --output-dir=%t.klee-out -no-interpolation %t1.bc
 // RUN: grep "total queries = 2" %t.klee-out/info
 
 #include <assert.h>


### PR DESCRIPTION
Added -no-interpolation option to KLEE. In addition, `make check` usually succeeds for this revision, however, `Dogfood/ImmutableSet.cpp` would likely fail occasionally.