### PR TITLE
Refined the Conditions for Solver Selection

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -44,13 +44,15 @@ enum QueryLoggingSolverType
  */
 extern llvm::cl::list<QueryLoggingSolverType> queryLoggingOptions;
 
+#if defined(SUPPORT_STP) && defined(SUPPORT_Z3)
 enum SolverType
 {
 	SOLVER_Z3,
 	SOLVER_STP
 };
 
-extern llvm::cl::opt<SolverType> selectSolver;
+extern llvm::cl::opt<SolverType> SelectSolver;
+#endif
 
 #ifdef SUPPORT_METASMT
 

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -73,14 +73,14 @@ llvm::cl::list<QueryLoggingSolverType> queryLoggingOptions(
     llvm::cl::CommaSeparated
 );
 
+#if defined(SUPPORT_STP) && defined(SUPPORT_Z3)
 llvm::cl::opt<SolverType>
-selectSolver("select-solver",
-				llvm::cl::desc("Select solver type, Z3 is default solver."),
-		        llvm::cl::values(clEnumValN(SOLVER_STP, "stp", "Use STP solver"),
-		                      clEnumValN(SOLVER_Z3, "z3", "Use Z3 solver"),
-		                      clEnumValEnd)
-			);
-
+SelectSolver("select-solver",
+             llvm::cl::desc("Select solver to use with z3 as the default."),
+             llvm::cl::values(clEnumValN(SOLVER_STP, "stp", "Use STP solver"),
+                              clEnumValN(SOLVER_Z3, "z3", "Use Z3 solver"),
+                              clEnumValEnd));
+#endif
 
 #ifdef SUPPORT_METASMT
 

--- a/tools/kleaver/main.cpp
+++ b/tools/kleaver/main.cpp
@@ -253,14 +253,82 @@ static bool EvaluateInputAST(const char *Filename,
     llvm::errs() << "Starting MetaSMTSolver(" << backend << ") ...\n";
   }
   else {
-    coreSolver = UseDummySolver ? createDummySolver() : new STPSolver(UseForkedCoreSolver);
+    if (UseDummySover) {
+      coreSolver = createDummySolver();
+      llvm::errs() << "Starting DummySolver ...\n";
+    } else {
+#ifdef SUPPORT_Z3
+#ifdef SUPPORT_STP
+      switch (SelectSolver) {
+      case SOLVER_STP: {
+        coreSolver = new STPSolver(UseForkedCoreSolver);
+        llvm::errs() << "Starting STPSolver ...\n";
+        break;
+      }
+      default: {
+        coreSolver = new Z3Solver();
+        llvm::errs() << "Starting Z3Solver ...\n";
+        break;
+      }
+      }
+#else
+      coreSolver = new Z3Solver();
+      llvm::errs() << "Starting Z3Solver ...\n";
+#endif /* SUPPORT_STP */
+#elif SUPPORT_STP
+      coreSolver = new STPSolver(UseForkedCoreSolver);
+      llvm::errs() << "Starting STPSolver ...\n";
+#else
+      coreSolver = createDummySolver();
+      llvm::errs() << "Starting DummySolver ...\n";
+#endif /* SUPPORT_Z3 */
+    }
   }
 #else
 #ifdef SUPPORT_Z3
-  coreSolver = UseDummySolver ? createDummySolver() : new Z3Solver();
+#ifdef SUPPORT_STP
+  switch (SelectSolver) {
+  case SOLVER_STP: {
+    if (UseDummySolver) {
+      coreSolver = createDummySolver();
+      llvm::errs() << "Starting DummySolver ...\n";
+    } else {
+      coreSolver = new STPSolver(UseForkedCoreSolver);
+      llvm::errs() << "Starting STPSolver ...\n";
+    }
+    break;
+  }
+  default: {
+    if (UseDummySolver) {
+      coreSolver = createDummySolver();
+      llvm::errs() << "Starting DummySolver ...\n";
+    } else {
+      coreSolver = new Z3Solver();
+      llvm::errs() << "Starting Z3Solver ...\n";
+    }
+    break;
+  }
+  }
 #else
-  coreSolver = UseDummySolver ? createDummySolver() : new STPSolver(UseForkedCoreSolver);
-#endif
+  if (UseDummySolver) {
+    coreSolver = createDummySolver();
+    llvm::errs() << "Starting DummySolver ...\n";
+  } else {
+    coreSolver = new Z3Solver();
+    llvm::errs() << "Starting Z3Solver ...\n";
+  }
+#endif /* SUPPORT_STP */
+#elif SUPPORT_STP
+  if (UseDummySolver) {
+    coreSolver = createDummySolver();
+    llvm::errs() << "Starting DummySolver ...\n";
+  } else {
+    coreSolver = new STPSolver(UseForkedCoreSolver);
+    llvm::errs() << "Starting STPSolver ...\n";
+  }
+#else
+  coreSolver = createDummySolver();
+#endif /* SUPPORT_Z3 */
 #endif /* SUPPORT_METASMT */
   
   


### PR DESCRIPTION
I made sure that when both STP and Z3 supports are enabled (compiled in), the interpolation routines are only called when Z3 was selected. I have also added printing on which is the solver used.