### PR TITLE
Handle Empty Query in Subsumption Check and Added Memory Dependency Tracking for PHI Nodes

### DIFF
--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -380,6 +380,9 @@ class Allocation {
     /// that are needed for the core and dominates other allocations.
     std::vector<Allocation *> interpolantAllocations;
 
+    /// @brief the basic block of the last-executed instruction
+    llvm::BasicBlock *lastBasicBlock;
+
     VersionedValue *getNewVersionedValue(llvm::Value *value,
                                          ref<Expr> valueExpr);
 

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1827,6 +1827,11 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     ref<Expr> result = eval(ki, state.incomingBBIndex * 2, state).value;
 #endif
     bindLocal(ki, state, result);
+#ifdef SUPPORT_Z3
+    // Update dependency
+    if (InterpolationOption::interpolation)
+      interpTree->executeAbstractDependency(i, result);
+#endif
     break;
   }
 
@@ -2916,13 +2921,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-       llvm::errs() << "\nCurrent state:\n";
-       processTree->dump();
-       interpTree->dump();
-       state.itreeNode->dump();
-       llvm::errs() << "------------------- Executing New Instruction "
-                       "-----------------------\n";
-       state.pc->inst->dump();
+      // llvm::errs() << "\nCurrent state:\n";
+      // processTree->dump();
+      // interpTree->dump();
+      // state.itreeNode->dump();
+      // llvm::errs() << "------------------- Executing New Instruction "
+      //                 "-----------------------\n";
+      // state.pc->inst->dump();
     }
 
     if (InterpolationOption::interpolation &&

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -227,9 +227,17 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
       state.itreeNode->makeMarkerMap();
 
   Solver::Validity result;
-  ref<Expr> query = stateEqualityConstraints.get()
-                        ? AndExpr::alloc(interpolant, stateEqualityConstraints)
-                        : interpolant;
+  ref<Expr> query;
+
+  if (interpolant.get()) {
+    query = stateEqualityConstraints.get()
+                ? AndExpr::alloc(interpolant, stateEqualityConstraints)
+                : interpolant;
+  } else if (stateEqualityConstraints.get()) {
+    query = stateEqualityConstraints;
+  } else {
+    query = ConstantExpr::create(0, Expr::Bool); // false
+  }
 
   if (!existentials.empty()) {
     query = simplifyExistsExpr(ExistsExpr::create(existentials, query));
@@ -452,10 +460,6 @@ std::pair<ITreeNode *, ITreeNode *> ITree::split(ITreeNode *parent, ExecutionSta
 
 void ITree::markPathCondition(ExecutionState &state, TimingSolver *solver) {
   std::vector<ref<Expr> > unsatCore = solver->getUnsatCore();
-
-  // Simply return in case the unsatisfiability core is empty
-  if (unsatCore.empty())
-      return;
 
   AllocationGraph *g = new AllocationGraph();
 


### PR DESCRIPTION
This PR contains two bugfixes. The first issue causes a memory access error in some examples, whereas the second issue causes assertion violation in the `Dependency` class, as the return value of a PHI node could not be found.