### PR TITLE
Fixed compilation error when --with-stp is not specified

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3777,6 +3777,8 @@ void Executor::runFunctionAsMain(Function *f,
   if (NoInterpolation ||
 #ifdef SUPPORT_STP
       SelectSolver != SOLVER_Z3
+#else
+      0
 #endif
       )
     // We globally declare that we don't do interpolation


### PR DESCRIPTION
Compilation error occurs when `--with-z3=...` is specified as an argument to `configure` and `--with-stp=...` isn't. This PR fixed it.
