### PR TITLE
Added Conditions in SubsumptionTableEntry::simplifyArithmeticBody

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -795,17 +795,22 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   if (isSeeding)
     timeout *= it->second.size();
 
-  // llvm::errs() << "Calling solver->evaluate on query:\n";
-  // ExprPPrinter::printQuery(llvm::errs(), current.constraints, condition);
+  llvm::errs() << "X0\n";
+  llvm::errs() << "Calling solver->evaluate on query:\n";
+  ExprPPrinter::printQuery(llvm::errs(), current.constraints, condition);
 
   solver->setTimeout(timeout);
   bool success = solver->evaluate(current, condition, res);
   solver->setTimeout(0);
+
+  llvm::errs() << "X1\n";
   if (!success) {
     current.pc = current.prevPC;
     terminateStateEarly(current, "Query timed out (fork).");
     return StatePair(0, 0);
   }
+
+  llvm::errs() << "X2\n";
 
   if (!isSeeding) {
     if (replayPath && !isInternal) {
@@ -856,6 +861,8 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     }
   }
 
+  llvm::errs() << "X3\n";
+
   // Fix branch in only-replay-seed mode, if we don't have both true
   // and false seeds.
   if (isSeeding && 
@@ -886,6 +893,8 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
                     trueSeed ? condition : Expr::createIsZero(condition));
     }
   }
+
+  llvm::errs() << "X4\n";
 
   // XXX - even if the constraint is provable one way or the other we
   // can probably benefit by adding this constraint and allowing it to
@@ -2921,13 +2930,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      // llvm::errs() << "\nCurrent state:\n";
-      // processTree->dump();
-      // interpTree->dump();
-      // state.itreeNode->dump();
-      // llvm::errs() << "------------------- Executing New Instruction "
-      //                 "-----------------------\n";
-      // state.pc->inst->dump();
+      llvm::errs() << "\nCurrent state:\n";
+      processTree->dump();
+      interpTree->dump();
+      state.itreeNode->dump();
+      llvm::errs() << "------------------- Executing New Instruction "
+                      "-----------------------\n";
+      state.pc->inst->dump();
     }
 
     if (InterpolationOption::interpolation &&

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -795,22 +795,18 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
   if (isSeeding)
     timeout *= it->second.size();
 
-  llvm::errs() << "X0\n";
-  llvm::errs() << "Calling solver->evaluate on query:\n";
-  ExprPPrinter::printQuery(llvm::errs(), current.constraints, condition);
+  // llvm::errs() << "Calling solver->evaluate on query:\n";
+  // ExprPPrinter::printQuery(llvm::errs(), current.constraints, condition);
 
   solver->setTimeout(timeout);
   bool success = solver->evaluate(current, condition, res);
   solver->setTimeout(0);
 
-  llvm::errs() << "X1\n";
   if (!success) {
     current.pc = current.prevPC;
     terminateStateEarly(current, "Query timed out (fork).");
     return StatePair(0, 0);
   }
-
-  llvm::errs() << "X2\n";
 
   if (!isSeeding) {
     if (replayPath && !isInternal) {
@@ -861,8 +857,6 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
     }
   }
 
-  llvm::errs() << "X3\n";
-
   // Fix branch in only-replay-seed mode, if we don't have both true
   // and false seeds.
   if (isSeeding && 
@@ -893,8 +887,6 @@ Executor::fork(ExecutionState &current, ref<Expr> condition, bool isInternal) {
                     trueSeed ? condition : Expr::createIsZero(condition));
     }
   }
-
-  llvm::errs() << "X4\n";
 
   // XXX - even if the constraint is provable one way or the other we
   // can probably benefit by adding this constraint and allowing it to
@@ -2930,13 +2922,13 @@ void Executor::run(ExecutionState &initialState) {
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
 
-      llvm::errs() << "\nCurrent state:\n";
-      processTree->dump();
-      interpTree->dump();
-      state.itreeNode->dump();
-      llvm::errs() << "------------------- Executing New Instruction "
-                      "-----------------------\n";
-      state.pc->inst->dump();
+      // llvm::errs() << "\nCurrent state:\n";
+      // processTree->dump();
+      // interpTree->dump();
+      // state.itreeNode->dump();
+      // llvm::errs() << "------------------- Executing New Instruction "
+      //                 "-----------------------\n";
+      // state.pc->inst->dump();
     }
 
     if (InterpolationOption::interpolation &&

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -189,7 +189,6 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr) {
   assert(ExistsExpr::classof(existsExpr.get()));
 
   ref<Expr> ret = simplifyArithmeticBody(existsExpr);
-  ret->dump();
   if (!ExistsExpr::classof(ret.get()))
     return ret;
 
@@ -199,7 +198,6 @@ ref<Expr> SubsumptionTableEntry::simplifyExistsExpr(ref<Expr> existsExpr) {
 bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
                                      ExecutionState& state,
                                      double timeout) {
-  llvm::errs() << "SUBSUMPTION CHECK\n";
   // Check if we are at the right program point
   if (state.itreeNode == 0 || reinterpret_cast<uintptr_t>(state.pc->inst) !=
                                   state.itreeNode->getNodeId() ||
@@ -269,7 +267,6 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   Solver::Validity result;
   ref<Expr> query;
 
-  llvm::errs() << "S1\n";
   // Here we build the query, after which it is always a conjunction of
   // the interpolant and the state equality constraints.
   if (interpolant.get()) {
@@ -284,14 +281,12 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     return true;
   }
 
-  llvm::errs() << "S2\n";
   if (!existentials.empty()) {
-      llvm::errs() << "S3\n";
     query = simplifyExistsExpr(ExistsExpr::create(existentials, query));
   }
 
-   llvm::errs() << "Querying for subsumption check:\n";
-   ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
+  // llvm::errs() << "Querying for subsumption check:\n";
+  // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
   bool success = false;
 
@@ -319,7 +314,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
   }
 
   if (success && result == Solver::True) {
-       llvm::errs() << "Solver decided validity\n";
+      // llvm::errs() << "Solver decided validity\n";
       std::vector<ref<Expr> > unsatCore;
       if (z3solver) {
         unsatCore = z3solver->getUnsatCore();

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -295,8 +295,11 @@ CexCachingSolver::~CexCachingSolver() {
 
 bool CexCachingSolver::computeValidity(const Query& query,
                                        Solver::Validity &result) {
+  llvm::errs() << "Y0\n";
   TimerStatIncrementer t(stats::cexCacheTime);
   Assignment *a;
+
+  llvm::errs() << "Y1\n";
 
   // Given query of the form antecedent -> consequent, here we try to
   // decide if antecedent was satisfiable by attempting to get an
@@ -304,12 +307,17 @@ bool CexCachingSolver::computeValidity(const Query& query,
   if (!getAssignment(query.withFalse(), a))
     return false;
 
+  llvm::errs() << "Y2\n";
+
   // Logically, antecedent must be satisfiable, as we eagerly terminate a
   // path upon the discovery of unsatisfiability.
   assert(a && "computeValidity() must have assignment");
+  query.expr->dump();
   ref<Expr> q = a->evaluate(query.expr);
   assert(isa<ConstantExpr>(q) && 
          "assignment evaluation did not result in constant");
+
+  llvm::errs() << "Y3\n";
 
   if (cast<ConstantExpr>(q)->isTrue()) {
     // Antecedent is satisfiable, and its model is also a model of the

--- a/lib/Solver/CexCachingSolver.cpp
+++ b/lib/Solver/CexCachingSolver.cpp
@@ -295,11 +295,8 @@ CexCachingSolver::~CexCachingSolver() {
 
 bool CexCachingSolver::computeValidity(const Query& query,
                                        Solver::Validity &result) {
-  llvm::errs() << "Y0\n";
   TimerStatIncrementer t(stats::cexCacheTime);
   Assignment *a;
-
-  llvm::errs() << "Y1\n";
 
   // Given query of the form antecedent -> consequent, here we try to
   // decide if antecedent was satisfiable by attempting to get an
@@ -307,17 +304,12 @@ bool CexCachingSolver::computeValidity(const Query& query,
   if (!getAssignment(query.withFalse(), a))
     return false;
 
-  llvm::errs() << "Y2\n";
-
   // Logically, antecedent must be satisfiable, as we eagerly terminate a
   // path upon the discovery of unsatisfiability.
   assert(a && "computeValidity() must have assignment");
-  query.expr->dump();
   ref<Expr> q = a->evaluate(query.expr);
   assert(isa<ConstantExpr>(q) && 
          "assignment evaluation did not result in constant");
-
-  llvm::errs() << "Y3\n";
 
   if (cast<ConstantExpr>(q)->isTrue()) {
     // Antecedent is satisfiable, and its model is also a model of the

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -1128,8 +1128,8 @@ SolverImpl::SolverRunStatus Z3SolverImpl::runAndGetCex(
 
   Z3_solver_assert(builder->ctx, the_solver, Z3_mk_not(builder->ctx, q));
 
-   llvm::errs() << "Solving: " << Z3_solver_to_string(builder->ctx, the_solver)
-               << "\n";
+  // llvm::errs() << "Solving: " << Z3_solver_to_string(builder->ctx, the_solver)
+  //             << "\n";
 
   switch (Z3_solver_check(builder->ctx, the_solver)) {
     case Z3_L_TRUE: {


### PR DESCRIPTION
The implementation of the simplifier is applicable only for limited cases currently, so I have added several if conditions in the methods' body to check for the conditions under which it is applicable. I think it is still important to develop tests for this procedure, as the conditions may not capture all cases where it is not applicable.