### PR TITLE
Added Generation of tree.dot in KLEE Output Directory

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -227,6 +227,12 @@ namespace {
                "Interpolation is enabled by default when Z3 was the solver "
                "used. This option has no effect when Z3 was not used."));
 
+  cl::opt<bool>
+  OutputTree("output-tree",
+             cl::desc("Outputs tree.dot: the execution tree in .dot file "
+                      "format. At present, this feature is only available when "
+                      "Z3 is compiled in and interpolation is enabled."));
+
   cl::opt<double>
   MaxStaticForkPct("max-static-fork-pct", cl::init(1.));
   cl::opt<double>
@@ -3784,6 +3790,9 @@ void Executor::runFunctionAsMain(Function *f,
       )
     // We globally declare that we don't do interpolation
     InterpolationOption::interpolation = false;
+  else if (OutputTree)
+    // We globally declare that we output the tree
+    InterpolationOption::outputTree = true;
 #endif /* SUPPORT_Z3 */
 
   std::vector<ref<Expr> > arguments;

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3871,6 +3871,7 @@ void Executor::runFunctionAsMain(Function *f,
   if (InterpolationOption::interpolation) {
     interpTree = new ITree(state);//added by Felicia
     state->itreeNode = interpTree->root;
+    SearchTree::initialize(interpTree->root);
   }
 #endif
 
@@ -3880,7 +3881,8 @@ void Executor::runFunctionAsMain(Function *f,
 
 #ifdef SUPPORT_Z3
   if (InterpolationOption::interpolation) {
-    interpTree->saveGraph(interpreterHandler->getOutputFilename("tree.dot"));
+    SearchTree::save(interpreterHandler->getOutputFilename("tree.dot"));
+    SearchTree::deallocate();
     delete interpTree;
     interpTree = 0;
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2916,7 +2916,7 @@ void Executor::run(ExecutionState &initialState) {
       // We synchronize the node id to that of the state. The node id
       // is set only when it was the address of the first instruction
       // in the node.
-      interpTree->setCurrentINode(state.itreeNode,
+      interpTree->setCurrentINode(state,
                                   reinterpret_cast<uintptr_t>(state.pc->inst));
 
       // Uncomment the following statements to show the state

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -2916,8 +2916,8 @@ void Executor::run(ExecutionState &initialState) {
       // We synchronize the node id to that of the state. The node id
       // is set only when it was the address of the first instruction
       // in the node.
-      state.itreeNode->setNodeLocation(reinterpret_cast<uintptr_t>(state.pc->inst));
-      interpTree->setCurrentINode(state.itreeNode);
+      interpTree->setCurrentINode(state.itreeNode,
+                                  reinterpret_cast<uintptr_t>(state.pc->inst));
 
       // Uncomment the following statements to show the state
       // of the interpolation tree and the active node.
@@ -3880,7 +3880,7 @@ void Executor::runFunctionAsMain(Function *f,
 
 #ifdef SUPPORT_Z3
   if (InterpolationOption::interpolation) {
-    interpTree->saveGraph("/tmp/graph.dot");
+    interpTree->saveGraph(interpreterHandler->getOutputFilename("tree.dot"));
     delete interpTree;
     interpTree = 0;
   }

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3880,6 +3880,7 @@ void Executor::runFunctionAsMain(Function *f,
 
 #ifdef SUPPORT_Z3
   if (InterpolationOption::interpolation) {
+    interpTree->saveGraph("/tmp/graph.dot");
     delete interpTree;
     interpTree = 0;
   }

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -20,6 +20,9 @@ using namespace klee;
 // Interpolation is enabled by default
 bool InterpolationOption::interpolation = true;
 
+// We don't output the three by default
+bool InterpolationOption::outputTree = false;
+
 /**/
 
 SearchTree::PrettyExpressionBuilder::QuantificationContext::
@@ -646,6 +649,9 @@ SearchTree::~SearchTree() {
 
 void SearchTree::addChildren(ITreeNode *parent, ITreeNode *falseChild,
                              ITreeNode *trueChild) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   SearchTree::Node *parentNode = instance->itreeNodeMap[parent];
@@ -658,6 +664,9 @@ void SearchTree::addChildren(ITreeNode *parent, ITreeNode *falseChild,
 
 void SearchTree::setCurrentNode(ExecutionState &state,
                                 const uintptr_t programPoint) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   ITreeNode *iTreeNode = state.itreeNode;
@@ -677,6 +686,9 @@ void SearchTree::setCurrentNode(ExecutionState &state,
 
 void SearchTree::markAsSubsumed(ITreeNode *iTreeNode,
                                 SubsumptionTableEntry *entry) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   SearchTree::Node *node = instance->itreeNodeMap[iTreeNode];
@@ -688,6 +700,9 @@ void SearchTree::markAsSubsumed(ITreeNode *iTreeNode,
 void SearchTree::addPathCondition(ITreeNode *iTreeNode,
                                   PathCondition *pathCondition,
                                   ref<Expr> condition) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   SearchTree::Node *node = instance->itreeNodeMap[iTreeNode];
@@ -701,6 +716,9 @@ void SearchTree::addPathCondition(ITreeNode *iTreeNode,
 
 void SearchTree::addTableEntryMapping(ITreeNode *iTreeNode,
                                       SubsumptionTableEntry *entry) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   SearchTree::Node *node = instance->itreeNodeMap[iTreeNode];
@@ -708,6 +726,9 @@ void SearchTree::addTableEntryMapping(ITreeNode *iTreeNode,
 }
 
 void SearchTree::includeInInterpolant(PathCondition *pathCondition) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   instance->pathConditionMap[pathCondition]->pathConditionTable[pathCondition].second = true;
@@ -715,6 +736,9 @@ void SearchTree::includeInInterpolant(PathCondition *pathCondition) {
 
 /// @brief Save the graph
 void SearchTree::save(std::string dotFileName) {
+  if (!InterpolationOption::outputTree)
+    return;
+
   assert(SearchTree::instance && "Search tree graph not initialized");
 
   std::string g(instance->render());

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -26,6 +26,138 @@ unsigned long SearchTree::nextNodeId = 1;
 
 SearchTree *SearchTree::instance = 0;
 
+std::string SearchTree::PrettyExpressionBuilder::bvOne(unsigned width) {}
+std::string SearchTree::PrettyExpressionBuilder::bvZero(unsigned width) {}
+std::string SearchTree::PrettyExpressionBuilder::bvMinusOne(unsigned width) {}
+std::string SearchTree::PrettyExpressionBuilder::bvConst32(unsigned width,
+                                                           uint32_t value) {}
+std::string SearchTree::PrettyExpressionBuilder::bvConst64(unsigned width,
+                                                           uint64_t value) {}
+std::string SearchTree::PrettyExpressionBuilder::bvZExtConst(unsigned width,
+                                                             uint64_t value) {}
+std::string SearchTree::PrettyExpressionBuilder::bvSExtConst(unsigned width,
+                                                             uint64_t value) {}
+
+std::string SearchTree::PrettyExpressionBuilder::bvBoolExtract(std::string expr,
+                                                               int bit) {}
+std::string SearchTree::PrettyExpressionBuilder::bvExtract(std::string expr,
+                                                           unsigned top,
+                                                           unsigned bottom) {}
+std::string SearchTree::PrettyExpressionBuilder::eqExpr(std::string a,
+                                                        std::string b) {}
+
+// logical left and right shift (not arithmetic)
+std::string SearchTree::PrettyExpressionBuilder::bvLeftShift(std::string expr,
+                                                             unsigned shift) {}
+std::string SearchTree::PrettyExpressionBuilder::bvRightShift(std::string expr,
+                                                              unsigned shift) {}
+std::string
+SearchTree::PrettyExpressionBuilder::bvVarLeftShift(std::string expr,
+                                                    std::string shift) {}
+std::string
+SearchTree::PrettyExpressionBuilder::bvVarRightShift(std::string expr,
+                                                     std::string shift) {}
+std::string
+SearchTree::PrettyExpressionBuilder::bvVarArithRightShift(std::string expr,
+                                                          std::string shift) {}
+
+// Some STP-style bitvector arithmetic
+std::string SearchTree::PrettyExpressionBuilder::bvMinusExpr(
+    unsigned width, std::string minuend, std::string subtrahend) {}
+std::string SearchTree::PrettyExpressionBuilder::bvPlusExpr(
+    unsigned width, std::string augend, std::string addend) {}
+std::string SearchTree::PrettyExpressionBuilder::bvMultExpr(
+    unsigned width, std::string multiplacand, std::string multiplier) {}
+std::string SearchTree::PrettyExpressionBuilder::bvDivExpr(
+    unsigned width, std::string dividend, std::string divisor) {}
+std::string SearchTree::PrettyExpressionBuilder::sbvDivExpr(
+    unsigned width, std::string dividend, std::string divisor) {}
+std::string SearchTree::PrettyExpressionBuilder::bvModExpr(
+    unsigned width, std::string dividend, std::string divisor) {}
+std::string SearchTree::PrettyExpressionBuilder::sbvModExpr(
+    unsigned width, std::string dividend, std::string divisor) {}
+std::string SearchTree::PrettyExpressionBuilder::notExpr(std::string expr) {}
+std::string SearchTree::PrettyExpressionBuilder::bvNotExpr(std::string expr) {}
+std::string SearchTree::PrettyExpressionBuilder::andExpr(std::string lhs,
+                                                         std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::bvAndExpr(std::string lhs,
+                                                           std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::orExpr(std::string lhs,
+                                                        std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::bvOrExpr(std::string lhs,
+                                                          std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::iffExpr(std::string lhs,
+                                                         std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::bvXorExpr(std::string lhs,
+                                                           std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::bvSignExtend(std::string src,
+                                                              unsigned width) {}
+
+// Some STP-style array domain interface
+std::string SearchTree::PrettyExpressionBuilder::writeExpr(std::string array,
+                                                           std::string index,
+                                                           std::string value) {}
+std::string SearchTree::PrettyExpressionBuilder::readExpr(std::string array,
+                                                          std::string index) {}
+
+// ITE-expression constructor
+std::string SearchTree::PrettyExpressionBuilder::iteExpr(
+    std::string condition, std::string whenTrue, std::string whenFalse) {}
+
+// Bitvector length
+int SearchTree::PrettyExpressionBuilder::getBVLength(std::string expr) {}
+
+// Bitvector comparison
+std::string SearchTree::PrettyExpressionBuilder::bvLtExpr(std::string lhs,
+                                                          std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::bvLeExpr(std::string lhs,
+                                                          std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::sbvLtExpr(std::string lhs,
+                                                           std::string rhs) {}
+std::string SearchTree::PrettyExpressionBuilder::sbvLeExpr(std::string lhs,
+                                                           std::string rhs) {}
+
+std::string SearchTree::PrettyExpressionBuilder::existsExpr(std::string body) {}
+
+std::string SearchTree::PrettyExpressionBuilder::constructAShrByConstant(
+    std::string expr, unsigned shift, std::string isSigned) {}
+std::string SearchTree::PrettyExpressionBuilder::constructMulByConstant(
+    std::string expr, unsigned width, uint64_t x) {}
+std::string SearchTree::PrettyExpressionBuilder::constructUDivByConstant(
+    std::string expr_n, unsigned width, uint64_t d) {}
+std::string SearchTree::PrettyExpressionBuilder::constructSDivByConstant(
+    std::string expr_n, unsigned width, uint64_t d) {}
+
+std::string
+SearchTree::PrettyExpressionBuilder::getInitialArray(const Array *os) {}
+std::string
+SearchTree::PrettyExpressionBuilder::getArrayForUpdate(const Array *root,
+                                                       const UpdateNode *un) {}
+
+std::string
+SearchTree::PrettyExpressionBuilder::constructActual(ref<Expr> e,
+                                                     int *width_out) {}
+std::string SearchTree::PrettyExpressionBuilder::construct(ref<Expr> e,
+                                                           int *width_out) {}
+
+std::string SearchTree::PrettyExpressionBuilder::buildVar(const char *name,
+                                                          unsigned width) {}
+std::string SearchTree::PrettyExpressionBuilder::buildArray(
+    const char *name, unsigned indexWidth, unsigned valueWidth) {}
+
+std::string SearchTree::PrettyExpressionBuilder::getTrue() {}
+std::string SearchTree::PrettyExpressionBuilder::getFalse() {}
+std::string SearchTree::PrettyExpressionBuilder::getTempVar(Expr::Width w) {}
+std::string
+SearchTree::PrettyExpressionBuilder::getInitialRead(const Array *os,
+                                                    unsigned index) {}
+
+SearchTree::PrettyExpressionBuilder::PrettyExpressionBuilder() {}
+
+SearchTree::PrettyExpressionBuilder::~PrettyExpressionBuilder() {}
+
+std::string SearchTree::PrettyExpressionBuilder::construct(ref<Expr> e) {}
+
 std::string SearchTree::recurseRender(const SearchTree::Node *node) {
   std::ostringstream stream;
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1326,7 +1326,10 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
 
     for (std::vector<ref<Expr> >::iterator it1 = unsatCore.begin();
          it1 != unsatCore.end(); it1++) {
-      markerMap[*it1]->mayIncludeInInterpolant();
+      // FIXME: Sometimes some constraints are not in the PC. This is
+      // because constraints are not properly added at state merge.
+      if (markerMap[*it1])
+        markerMap[*it1]->mayIncludeInInterpolant();
     }
 
   } else {
@@ -1677,8 +1680,10 @@ std::map<ref<Expr>, PathConditionMarker *> ITreeNode::makeMarkerMap() const {
   for (PathCondition *it = pathCondition; it != 0; it = it->cdr()) {
     PathConditionMarker *marker = new PathConditionMarker(it);
     if (llvm::isa<OrExpr>(it->car().get())) {
-      // Break up disjunction into its components, because each disjunct
-      // is solved separately
+      // FIXME: Break up disjunction into its components, because each disjunct
+      // is solved separately. The or constraint was due to state merge.
+      // Hence, the following is just a makeshift for when state merge is
+      // properly implemented.
       result.insert(std::pair<ref<Expr>, PathConditionMarker *>(
           it->car()->getKid(0), marker));
       result.insert(std::pair<ref<Expr>, PathConditionMarker *>(

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -111,8 +111,8 @@ void SearchTree::markAsSubsumed() { activeNode->subsumed = true; }
 void SearchTree::addPathCondition(ITreeNode *iTreeNode, ref<Expr> condition) {
   SearchTree::Node *node = itreeNodeMap[iTreeNode];
 
-  std::string &buffer(10000, 0);
-  llvm::raw_string_ostream stream(buffer);
+  std::string constraintStr;
+  llvm::raw_string_ostream stream(constraintStr);
   condition->print(stream);
   std::string s = stream.str();
   s.erase(std::remove(s.begin(), s.end(), '\n'), s.end());

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -94,24 +94,24 @@ std::string SearchTree::PrettyExpressionBuilder::eqExpr(std::string a,
 std::string SearchTree::PrettyExpressionBuilder::bvLeftShift(std::string expr,
                                                              unsigned shift) {
   std::ostringstream stream;
-  stream << "(" << expr << " << " << shift << ")";
+  stream << "(" << expr << " \\<\\< " << shift << ")";
   return stream.str();
 }
 std::string SearchTree::PrettyExpressionBuilder::bvRightShift(std::string expr,
                                                               unsigned shift) {
   std::ostringstream stream;
-  stream << "(" << expr << " >> " << shift << ")";
+  stream << "(" << expr << " \\>\\> " << shift << ")";
   return stream.str();
 }
 std::string
 SearchTree::PrettyExpressionBuilder::bvVarLeftShift(std::string expr,
                                                     std::string shift) {
-  return "(" + expr + " << " + shift + ")";
+  return "(" + expr + " \\<\\< " + shift + ")";
 }
 std::string
 SearchTree::PrettyExpressionBuilder::bvVarRightShift(std::string expr,
                                                      std::string shift) {
-  return "(" + expr + " >> " + shift + ")";
+  return "(" + expr + " \\>\\> " + shift + ")";
 }
 std::string
 SearchTree::PrettyExpressionBuilder::bvVarArithRightShift(std::string expr,
@@ -168,7 +168,7 @@ std::string SearchTree::PrettyExpressionBuilder::bvOrExpr(std::string lhs,
 }
 std::string SearchTree::PrettyExpressionBuilder::iffExpr(std::string lhs,
                                                          std::string rhs) {
-  return "(" + lhs + " <=> " + rhs + ")";
+  return "(" + lhs + " \\<=\\> " + rhs + ")";
 }
 std::string SearchTree::PrettyExpressionBuilder::bvXorExpr(std::string lhs,
                                                            std::string rhs) {
@@ -198,19 +198,19 @@ std::string SearchTree::PrettyExpressionBuilder::iteExpr(
 // Bitvector comparison
 std::string SearchTree::PrettyExpressionBuilder::bvLtExpr(std::string lhs,
                                                           std::string rhs) {
-  return "(" + lhs + " < " + rhs + ")";
+  return "(" + lhs + " \\< " + rhs + ")";
 }
 std::string SearchTree::PrettyExpressionBuilder::bvLeExpr(std::string lhs,
                                                           std::string rhs) {
-  return "(" + lhs + " <= " + rhs + ")";
+  return "(" + lhs + " \\<= " + rhs + ")";
 }
 std::string SearchTree::PrettyExpressionBuilder::sbvLtExpr(std::string lhs,
                                                            std::string rhs) {
-  return "(" + lhs + " < " + rhs + ")";
+  return "(" + lhs + " \\< " + rhs + ")";
 }
 std::string SearchTree::PrettyExpressionBuilder::sbvLeExpr(std::string lhs,
                                                            std::string rhs) {
-  return "(" + lhs + " <= " + rhs + ")";
+  return "(" + lhs + " \\<= " + rhs + ")";
 }
 
 std::string SearchTree::PrettyExpressionBuilder::existsExpr(std::string body) {
@@ -1354,7 +1354,10 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
            it = markerMap.begin(),
            itEnd = markerMap.end();
        it != itEnd; it++) {
-    it->second->includeInInterpolant(g);
+    // FIXME: Sometimes some constraints are not in the PC. This is
+    // because constraints are not properly added at state merge.
+    if (it->second)
+      it->second->includeInInterpolant(g);
   }
   ITreeNode::deleteMarkerMap(markerMap);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -166,6 +166,9 @@ class SearchTree {
     /// @brief Conditions under which this node is visited from its parent
     std::map<PathCondition *, std::pair<std::string, bool> > pathConditionTable;
 
+    /// @brief Human-readable identifier of this node
+    std::string name;
+
     Node(uintptr_t nodeId)
         : iTreeNodeId(nodeId), nodeId(0), falseTarget(0), trueTarget(0),
           subsumed(false) {}
@@ -215,7 +218,7 @@ public:
   static void addChildren(ITreeNode *parent, ITreeNode *falseChild,
                           ITreeNode *trueChild);
 
-  static void setCurrentNode(ITreeNode *iTreeNode,
+  static void setCurrentNode(ExecutionState &state,
                              const uintptr_t programPoint);
 
   static void markAsSubsumed(ITreeNode *iTreeNode,
@@ -377,7 +380,7 @@ public:
 
   void store(SubsumptionTableEntry *subItem);
 
-  void setCurrentINode(ITreeNode *node, uintptr_t programPoint);
+  void setCurrentINode(ExecutionState &state, uintptr_t programPoint);
 
   void remove(ITreeNode *node);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -21,6 +21,8 @@ using namespace llvm;
 namespace klee {
 class ExecutionState;
 
+class SubsumptionTableEntry;
+
 /// Global variable denoting whether interpolation is enabled or otherwise
 struct InterpolationOption {
   static bool interpolation;
@@ -73,6 +75,8 @@ class SearchTree {
   SearchTree::Node *root;
   SearchTree::Node *activeNode;
   std::map<ITreeNode *, SearchTree::Node *> itreeNodeMap;
+  std::map<SubsumptionTableEntry *, SearchTree::Node *> tableEntryMap;
+  std::map<SearchTree::Node *, SearchTree::Node *> subsumptionEdges;
 
   static std::string recurseRender(const SearchTree::Node *node);
 
@@ -87,9 +91,11 @@ public:
 
   void setCurrentNode(ITreeNode *iTreeNode, const uintptr_t programPoint);
 
-  void markAsSubsumed();
+  void markAsSubsumed(ITreeNode *iTreeNode, SubsumptionTableEntry *entry);
 
   void addPathCondition(ITreeNode *iTreeNode, ref<Expr> condition);
+
+  void addTableEntryMapping(ITreeNode *iTreeNode, SubsumptionTableEntry *entry);
 
   /// @brief Save the graph
   void save(std::string dotFileName);
@@ -221,7 +227,7 @@ class ITree {
 
   ITreeNode *currentINode;
 
-  std::vector<SubsumptionTableEntry> subsumptionTable;
+  std::vector<SubsumptionTableEntry *> subsumptionTable;
 
   /// @brief Graph for displaying as .dot file
   SearchTree *graph;
@@ -235,9 +241,9 @@ public:
 
   ~ITree();
 
-  std::vector<SubsumptionTableEntry> getStore();
+  std::vector<SubsumptionTableEntry *> getStore();
 
-  void store(SubsumptionTableEntry subItem);
+  void store(SubsumptionTableEntry *subItem);
 
   void setCurrentINode(ITreeNode *node, uintptr_t programPoint);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -42,13 +42,34 @@ class SearchTree {
   /// Encapsulates functionality of expression builder
   class PrettyExpressionBuilder {
 
-    std::string bvOne(unsigned width);
-    std::string bvZero(unsigned width);
-    std::string bvMinusOne(unsigned width);
-    std::string bvConst32(unsigned width, uint32_t value);
-    std::string bvConst64(unsigned width, uint64_t value);
-    std::string bvZExtConst(unsigned width, uint64_t value);
-    std::string bvSExtConst(unsigned width, uint64_t value);
+    class QuantificationContext {
+
+      std::string existentials;
+
+      QuantificationContext *parent;
+
+    public:
+      QuantificationContext(std::vector<const Array *> _existentials,
+                            QuantificationContext *_parent);
+
+      ~QuantificationContext();
+
+      QuantificationContext *getParent() { return parent; }
+
+      std::string getExistentials() { return existentials; }
+    };
+
+    std::string bvOne() {
+      return "1";
+    };
+    std::string bvZero() {
+      return "0";
+    };
+    std::string bvMinusOne() { return "-1"; }
+    std::string bvConst32(uint32_t value);
+    std::string bvConst64(uint64_t value);
+    std::string bvZExtConst(uint64_t value);
+    std::string bvSExtConst(uint64_t value);
 
     std::string bvBoolExtract(std::string expr, int bit);
     std::string bvExtract(std::string expr, unsigned top, unsigned bottom);
@@ -62,29 +83,19 @@ class SearchTree {
     std::string bvVarArithRightShift(std::string expr, std::string shift);
 
     // Some STP-style bitvector arithmetic
-    std::string bvMinusExpr(unsigned width, std::string minuend,
-                            std::string subtrahend);
-    std::string bvPlusExpr(unsigned width, std::string augend,
-                           std::string addend);
-    std::string bvMultExpr(unsigned width, std::string multiplacand,
-                           std::string multiplier);
-    std::string bvDivExpr(unsigned width, std::string dividend,
-                          std::string divisor);
-    std::string sbvDivExpr(unsigned width, std::string dividend,
-                           std::string divisor);
-    std::string bvModExpr(unsigned width, std::string dividend,
-                          std::string divisor);
-    std::string sbvModExpr(unsigned width, std::string dividend,
-                           std::string divisor);
+    std::string bvMinusExpr(std::string minuend, std::string subtrahend);
+    std::string bvPlusExpr(std::string augend, std::string addend);
+    std::string bvMultExpr(std::string multiplacand, std::string multiplier);
+    std::string bvDivExpr(std::string dividend, std::string divisor);
+    std::string sbvDivExpr(std::string dividend, std::string divisor);
+    std::string bvModExpr(std::string dividend, std::string divisor);
+    std::string sbvModExpr(std::string dividend, std::string divisor);
     std::string notExpr(std::string expr);
-    std::string bvNotExpr(std::string expr);
-    std::string andExpr(std::string lhs, std::string rhs);
     std::string bvAndExpr(std::string lhs, std::string rhs);
-    std::string orExpr(std::string lhs, std::string rhs);
     std::string bvOrExpr(std::string lhs, std::string rhs);
     std::string iffExpr(std::string lhs, std::string rhs);
     std::string bvXorExpr(std::string lhs, std::string rhs);
-    std::string bvSignExtend(std::string src, unsigned width);
+    std::string bvSignExtend(std::string src);
 
     // Some STP-style array domain interface
     std::string writeExpr(std::string array, std::string index,
@@ -94,9 +105,6 @@ class SearchTree {
     // ITE-expression constructor
     std::string iteExpr(std::string condition, std::string whenTrue,
                         std::string whenFalse);
-
-    // Bitvector length
-    int getBVLength(std::string expr);
 
     // Bitvector comparison
     std::string bvLtExpr(std::string lhs, std::string rhs);
@@ -108,34 +116,35 @@ class SearchTree {
 
     std::string constructAShrByConstant(std::string expr, unsigned shift,
                                         std::string isSigned);
-    std::string constructMulByConstant(std::string expr, unsigned width,
-                                       uint64_t x);
-    std::string constructUDivByConstant(std::string expr_n, unsigned width,
-                                        uint64_t d);
-    std::string constructSDivByConstant(std::string expr_n, unsigned width,
-                                        uint64_t d);
+    std::string constructMulByConstant(std::string expr, uint64_t x);
+    std::string constructUDivByConstant(std::string expr_n, uint64_t d);
+    std::string constructSDivByConstant(std::string expr_n, uint64_t d);
 
-    std::string getInitialArray(const Array *os);
+    std::string getInitialArray(const Array *root);
     std::string getArrayForUpdate(const Array *root, const UpdateNode *un);
 
-    std::string constructActual(ref<Expr> e, int *width_out);
-    std::string construct(ref<Expr> e, int *width_out);
+    std::string constructActual(ref<Expr> e);
 
-    std::string buildVar(const char *name, unsigned width);
     std::string buildArray(const char *name, unsigned indexWidth,
                            unsigned valueWidth);
 
     std::string getTrue();
     std::string getFalse();
-    std::string getTempVar(Expr::Width w);
-    std::string getInitialRead(const Array *os, unsigned index);
+    std::string getInitialRead(const Array *root, unsigned index);
 
-  public:
+    // Handling of quantification contexts
+    QuantificationContext *quantificationContext;
+
+    void pushQuantificationContext(std::vector<const Array *> existentials);
+
+    void popQuantificationContext();
+
     PrettyExpressionBuilder();
 
     ~PrettyExpressionBuilder();
 
-    std::string construct(ref<Expr> e);
+  public:
+    static std::string construct(ref<Expr> e);
   };
 
   /// Node information

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -39,6 +39,105 @@ class SearchTree {
   /// @brief Global search tree instance
   static SearchTree *instance;
 
+  /// Encapsulates functionality of expression builder
+  class PrettyExpressionBuilder {
+
+    std::string bvOne(unsigned width);
+    std::string bvZero(unsigned width);
+    std::string bvMinusOne(unsigned width);
+    std::string bvConst32(unsigned width, uint32_t value);
+    std::string bvConst64(unsigned width, uint64_t value);
+    std::string bvZExtConst(unsigned width, uint64_t value);
+    std::string bvSExtConst(unsigned width, uint64_t value);
+
+    std::string bvBoolExtract(std::string expr, int bit);
+    std::string bvExtract(std::string expr, unsigned top, unsigned bottom);
+    std::string eqExpr(std::string a, std::string b);
+
+    // logical left and right shift (not arithmetic)
+    std::string bvLeftShift(std::string expr, unsigned shift);
+    std::string bvRightShift(std::string expr, unsigned shift);
+    std::string bvVarLeftShift(std::string expr, std::string shift);
+    std::string bvVarRightShift(std::string expr, std::string shift);
+    std::string bvVarArithRightShift(std::string expr, std::string shift);
+
+    // Some STP-style bitvector arithmetic
+    std::string bvMinusExpr(unsigned width, std::string minuend,
+                            std::string subtrahend);
+    std::string bvPlusExpr(unsigned width, std::string augend,
+                           std::string addend);
+    std::string bvMultExpr(unsigned width, std::string multiplacand,
+                           std::string multiplier);
+    std::string bvDivExpr(unsigned width, std::string dividend,
+                          std::string divisor);
+    std::string sbvDivExpr(unsigned width, std::string dividend,
+                           std::string divisor);
+    std::string bvModExpr(unsigned width, std::string dividend,
+                          std::string divisor);
+    std::string sbvModExpr(unsigned width, std::string dividend,
+                           std::string divisor);
+    std::string notExpr(std::string expr);
+    std::string bvNotExpr(std::string expr);
+    std::string andExpr(std::string lhs, std::string rhs);
+    std::string bvAndExpr(std::string lhs, std::string rhs);
+    std::string orExpr(std::string lhs, std::string rhs);
+    std::string bvOrExpr(std::string lhs, std::string rhs);
+    std::string iffExpr(std::string lhs, std::string rhs);
+    std::string bvXorExpr(std::string lhs, std::string rhs);
+    std::string bvSignExtend(std::string src, unsigned width);
+
+    // Some STP-style array domain interface
+    std::string writeExpr(std::string array, std::string index,
+                          std::string value);
+    std::string readExpr(std::string array, std::string index);
+
+    // ITE-expression constructor
+    std::string iteExpr(std::string condition, std::string whenTrue,
+                        std::string whenFalse);
+
+    // Bitvector length
+    int getBVLength(std::string expr);
+
+    // Bitvector comparison
+    std::string bvLtExpr(std::string lhs, std::string rhs);
+    std::string bvLeExpr(std::string lhs, std::string rhs);
+    std::string sbvLtExpr(std::string lhs, std::string rhs);
+    std::string sbvLeExpr(std::string lhs, std::string rhs);
+
+    std::string existsExpr(std::string body);
+
+    std::string constructAShrByConstant(std::string expr, unsigned shift,
+                                        std::string isSigned);
+    std::string constructMulByConstant(std::string expr, unsigned width,
+                                       uint64_t x);
+    std::string constructUDivByConstant(std::string expr_n, unsigned width,
+                                        uint64_t d);
+    std::string constructSDivByConstant(std::string expr_n, unsigned width,
+                                        uint64_t d);
+
+    std::string getInitialArray(const Array *os);
+    std::string getArrayForUpdate(const Array *root, const UpdateNode *un);
+
+    std::string constructActual(ref<Expr> e, int *width_out);
+    std::string construct(ref<Expr> e, int *width_out);
+
+    std::string buildVar(const char *name, unsigned width);
+    std::string buildArray(const char *name, unsigned indexWidth,
+                           unsigned valueWidth);
+
+    std::string getTrue();
+    std::string getFalse();
+    std::string getTempVar(Expr::Width w);
+    std::string getInitialRead(const Array *os, unsigned index);
+
+  public:
+    PrettyExpressionBuilder();
+
+    ~PrettyExpressionBuilder();
+
+    std::string construct(ref<Expr> e);
+  };
+
   /// Node information
   class Node {
     friend class SearchTree;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -25,9 +25,15 @@ class PathCondition;
 
 class SubsumptionTableEntry;
 
-/// Global variable denoting whether interpolation is enabled or otherwise
+/// Options for global interpolation mechanism
 struct InterpolationOption {
+
+  /// @brief Global variable denoting whether interpolation is enabled or
+  /// otherwise
   static bool interpolation;
+
+  /// @brief Output the tree tree.dot in .dot file format
+  static bool outputTree;
 };
 
 /// Storage of search tree for displaying
@@ -204,12 +210,18 @@ class SearchTree {
 
 public:
   static void initialize(ITreeNode *root) {
+    if (!InterpolationOption::outputTree)
+      return;
+
     if (!instance)
       delete instance;
     instance = new SearchTree(root);
   }
 
   static void deallocate() {
+    if (!InterpolationOption::outputTree)
+      return;
+
     if (!instance)
       delete instance;
     instance = 0;


### PR DESCRIPTION
The `tree.dot` file is a DOT file of the symbolic execution tree. Enable its generation using `-output-tree` option. This option is currently only effective when Z3 interface is compiled in and interpolation is enabled (not switched off using `-no-interpolation` option). To get the PDF file `tree.pdf` from `tree.dot`, say `dot -Tpdf tree.dot -o tree.pdf`. On Ubuntu, this requires the installation of `graphviz` package.