### PR TITLE
Added -interpolation-time-stat Option

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -233,6 +233,11 @@ namespace {
                       "format. At present, this feature is only available when "
                       "Z3 is compiled in and interpolation is enabled."));
 
+  cl::opt<bool> InterpolationTimeStat(
+      "interpolation-time-stat",
+      cl::desc(
+          "Displays a summary of execution times of interpolation methods."));
+
   cl::opt<double>
   MaxStaticForkPct("max-static-fork-pct", cl::init(1.));
   cl::opt<double>
@@ -3790,9 +3795,14 @@ void Executor::runFunctionAsMain(Function *f,
       )
     // We globally declare that we don't do interpolation
     InterpolationOption::interpolation = false;
-  else if (OutputTree)
-    // We globally declare that we output the tree
-    InterpolationOption::outputTree = true;
+  else {
+    if (OutputTree)
+      // We globally declare that we output the tree
+      InterpolationOption::outputTree = true;
+    if (InterpolationTimeStat)
+      // To display execution times of interpolation methods
+      InterpolationOption::timeStat = true;
+  }
 #endif /* SUPPORT_Z3 */
 
   std::vector<ref<Expr> > arguments;
@@ -3893,10 +3903,12 @@ void Executor::runFunctionAsMain(Function *f,
     SearchTree::save(interpreterHandler->getOutputFilename("tree.dot"));
     SearchTree::deallocate();
 
-    // Print time statistics
-    SubsumptionTableEntry::dumpTimeStat();
-    ITree::dumpTimeStat();
-    ITreeNode::dumpTimeStat();
+    // Print interpolation time statistics
+    if (InterpolationOption::timeStat) {
+      SubsumptionTableEntry::dumpTimeStat();
+      ITree::dumpTimeStat();
+      ITreeNode::dumpTimeStat();
+    }
 
     delete interpTree;
     interpTree = 0;

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -809,6 +809,10 @@ void PathCondition::print(llvm::raw_ostream &stream) {
 
 TimeStat SubsumptionTableEntry::actualSolverCallTime;
 
+unsigned long SubsumptionTableEntry::checkSolverCount = 0;
+
+unsigned long SubsumptionTableEntry::checkSolverFailureCount = 0;
+
 SubsumptionTableEntry::SubsumptionTableEntry(ITreeNode *node)
     : nodeId(node->getNodeId()) {
   std::vector<const Array *> replacements;
@@ -1282,6 +1286,8 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     // llvm::errs() << "Querying for subsumption check:\n";
     // ExprPPrinter::printQuery(llvm::errs(), state.constraints, query);
 
+    ++checkSolverCount;
+
     if (!existentials.empty() && llvm::isa<ExistsExpr>(query)) {
       // llvm::errs() << "Existentials not empty\n";
 
@@ -1345,6 +1351,7 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     // invalidity is established by the solver.
     // llvm::errs() << "Solver could not decide validity\n";
 
+    ++checkSolverFailureCount;
     if (z3solver)
       delete z3solver;
 
@@ -1450,6 +1457,9 @@ void SubsumptionTableEntry::printTimeStat(llvm::raw_ostream &stream) {
   stream
       << "KLEE: done:     Time for actual solver calls in subsumption check: "
       << actualSolverCallTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     Number of solver calls for subsumption check "
+            "(failed): " << checkSolverCount << " (" << checkSolverFailureCount
+         << ")\n";
 }
 
 void SubsumptionTableEntry::dumpTimeStat() {

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1455,10 +1455,10 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
 void SubsumptionTableEntry::printTimeStat(llvm::raw_ostream &stream) {
   stream << "\nKLEE: done: SubsumptionTableEntry timings (ms):\n";
   stream
-      << "KLEE: done:     Time for actual solver calls in subsumption check: "
+      << "KLEE: done:     Time for actual solver calls in subsumption check = "
       << actualSolverCallTime.get() * 1000 << "\n";
   stream << "KLEE: done:     Number of solver calls for subsumption check "
-            "(failed): " << checkSolverCount << " (" << checkSolverFailureCount
+            "(failed) = " << checkSolverCount << " (" << checkSolverFailureCount
          << ")\n";
 }
 
@@ -1486,19 +1486,19 @@ TimeStat ITree::executeAbstractDependencyTime;
 
 void ITree::printTimeStat(llvm::raw_ostream &stream) {
   stream << "\nKLEE: done: ITree method execution times (ms):\n";
-  stream << "KLEE: done:     setCurrentINode: " << setCurrentINodeTime.get() *
-                                                       1000 << "\n";
-  stream << "KLEE: done:     remove: " << removeTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     checkCurrentStateSubsumption: "
+  stream << "KLEE: done:     setCurrentINode = " << setCurrentINodeTime.get() *
+                                                        1000 << "\n";
+  stream << "KLEE: done:     remove = " << removeTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     checkCurrentStateSubsumption = "
          << checkCurrentStateSubsumptionTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     markPathCondition: "
+  stream << "KLEE: done:     markPathCondition = "
          << markPathConditionTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     split: " << splitTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     executeAbstractBinaryDependency: "
+  stream << "KLEE: done:     split = " << splitTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     executeAbstractBinaryDependency = "
          << executeAbstractBinaryDependencyTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     executeAbstractMemoryDependency: "
+  stream << "KLEE: done:     executeAbstractMemoryDependency = "
          << executeAbstractMemoryDependencyTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     executeAbstractDependency: "
+  stream << "KLEE: done:     executeAbstractDependency = "
          << executeAbstractDependencyTime.get() * 1000 << "\n";
 }
 
@@ -1740,34 +1740,34 @@ TimeStat ITreeNode::computeInterpolantAllocationsTime;
 
 void ITreeNode::printTimeStat(llvm::raw_ostream &stream) {
   stream << "\nKLEE: done: ITreeNode method execution times (ms):\n";
-  stream << "KLEE: done:     getInterpolant: " << getInterpolantTime.get() *
-                                                      1000 << "\n";
-  stream << "KLEE: done:     addConstraintTime: " << addConstraintTime.get() *
-                                                         1000 << "\n";
-  stream << "KLEE: done:     splitTime: " << splitTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     makeMarkerMap: " << makeMarkerMapTime.get() * 1000
-         << "\n";
-  stream << "KLEE: done:     deleteMarkerMap: " << deleteMarkerMapTime.get() *
+  stream << "KLEE: done:     getInterpolant = " << getInterpolantTime.get() *
                                                        1000 << "\n";
-  stream << "KLEE: done:     executeBinaryDependency: "
+  stream << "KLEE: done:     addConstraintTime = " << addConstraintTime.get() *
+                                                          1000 << "\n";
+  stream << "KLEE: done:     splitTime = " << splitTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     makeMarkerMap = " << makeMarkerMapTime.get() * 1000
+         << "\n";
+  stream << "KLEE: done:     deleteMarkerMap = " << deleteMarkerMapTime.get() *
+                                                        1000 << "\n";
+  stream << "KLEE: done:     executeBinaryDependency = "
          << executeBinaryDependencyTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     executeAbstractMemoryDependency: "
+  stream << "KLEE: done:     executeAbstractMemoryDependency = "
          << executeAbstractMemoryDependencyTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     executeAbstractDependency: "
+  stream << "KLEE: done:     executeAbstractDependency = "
          << executeAbstractDependencyTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     bindCallArguments: "
+  stream << "KLEE: done:     bindCallArguments = "
          << bindCallArgumentsTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     popAbstractDependencyFrame: "
+  stream << "KLEE: done:     popAbstractDependencyFrame = "
          << popAbstractDependencyFrameTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     getLatestCoreExpressions: "
+  stream << "KLEE: done:     getLatestCoreExpressions = "
          << getLatestCoreExpressionsTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     getCompositeCoreExpressions: "
+  stream << "KLEE: done:     getCompositeCoreExpressions = "
          << getCompositeCoreExpressionsTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     getLatestInterpolantCoreExpressions: "
+  stream << "KLEE: done:     getLatestInterpolantCoreExpressions = "
          << getLatestCoreExpressionsTime.get() << "\n";
-  stream << "KLEE: done:     getCompositeInterpolantCoreExpressions: "
+  stream << "KLEE: done:     getCompositeInterpolantCoreExpressions = "
          << getCompositeInterpolantCoreExpressionsTime.get() * 1000 << "\n";
-  stream << "KLEE: done:     computeInterpolantAllocations: "
+  stream << "KLEE: done:     computeInterpolantAllocations = "
          << computeInterpolantAllocationsTime.get() * 1000 << "\n";
 }
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -23,6 +23,9 @@ bool InterpolationOption::interpolation = true;
 // We don't output the three by default
 bool InterpolationOption::outputTree = false;
 
+// We don't display interpolation methods running times by default
+bool InterpolationOption::timeStat = false;
+
 /**/
 
 std::string SearchTree::PrettyExpressionBuilder::bvConst32(uint32_t value) {
@@ -1443,9 +1446,21 @@ void SubsumptionTableEntry::print(llvm::raw_ostream &stream) const {
 }
 
 void SubsumptionTableEntry::printTimeStat(llvm::raw_ostream &stream) {
-  stream << "\nSubsumptionTableEntry timings (ms):\n";
-  stream << "Time for actual solver calls in subsumption check: "
-         << actualSolverCallTime.get() * 1000 << "\n";
+  stream << "\nKLEE: done: SubsumptionTableEntry timings (ms):\n";
+  stream
+      << "KLEE: done:     Time for actual solver calls in subsumption check: "
+      << actualSolverCallTime.get() * 1000 << "\n";
+}
+
+void SubsumptionTableEntry::dumpTimeStat() {
+  bool useColors = llvm::errs().is_displayed();
+  if (useColors)
+    llvm::errs().changeColor(llvm::raw_ostream::GREEN,
+                             /*bold=*/true,
+                             /*bg=*/false);
+  printTimeStat(llvm::errs());
+  if (useColors)
+    llvm::errs().resetColor();
 }
 
 /**/
@@ -1460,19 +1475,32 @@ TimeStat ITree::executeAbstractMemoryDependencyTime;
 TimeStat ITree::executeAbstractDependencyTime;
 
 void ITree::printTimeStat(llvm::raw_ostream &stream) {
-  stream << "\nITree method execution times (ms):\n";
-  stream << "setCurrentINode: " << setCurrentINodeTime.get() * 1000 << "\n";
-  stream << "remove: " << removeTime.get() * 1000 << "\n";
-  stream << "checkCurrentStateSubsumption: "
+  stream << "\nKLEE: done: ITree method execution times (ms):\n";
+  stream << "KLEE: done:     setCurrentINode: " << setCurrentINodeTime.get() *
+                                                       1000 << "\n";
+  stream << "KLEE: done:     remove: " << removeTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     checkCurrentStateSubsumption: "
          << checkCurrentStateSubsumptionTime.get() * 1000 << "\n";
-  stream << "markPathCondition: " << markPathConditionTime.get() * 1000 << "\n";
-  stream << "split: " << splitTime.get() * 1000 << "\n";
-  stream << "executeAbstractBinaryDependency: "
+  stream << "KLEE: done:     markPathCondition: "
+         << markPathConditionTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     split: " << splitTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     executeAbstractBinaryDependency: "
          << executeAbstractBinaryDependencyTime.get() * 1000 << "\n";
-  stream << "executeAbstractMemoryDependency: "
+  stream << "KLEE: done:     executeAbstractMemoryDependency: "
          << executeAbstractMemoryDependencyTime.get() * 1000 << "\n";
-  stream << "executeAbstractDependency: "
+  stream << "KLEE: done:     executeAbstractDependency: "
          << executeAbstractDependencyTime.get() * 1000 << "\n";
+}
+
+void ITree::dumpTimeStat() {
+  bool useColors = llvm::errs().is_displayed();
+  if (useColors)
+    llvm::errs().changeColor(llvm::raw_ostream::GREEN,
+                             /*bold=*/true,
+                             /*bg=*/false);
+  printTimeStat(llvm::errs());
+  if (useColors)
+    llvm::errs().resetColor();
 }
 
 ITree::ITree(ExecutionState *_root) {
@@ -1701,31 +1729,47 @@ TimeStat ITreeNode::getCompositeInterpolantCoreExpressionsTime;
 TimeStat ITreeNode::computeInterpolantAllocationsTime;
 
 void ITreeNode::printTimeStat(llvm::raw_ostream &stream) {
-  stream << "\nITreeNode method execution times (ms):\n";
-  stream << "getInterpolant: " << getInterpolantTime.get() * 1000 << "\n";
-  stream << "addConstraintTime: " << addConstraintTime.get() * 1000 << "\n";
-  stream << "splitTime: " << splitTime.get() * 1000 << "\n";
-  stream << "makeMarkerMap: " << makeMarkerMapTime.get() * 1000 << "\n";
-  stream << "deleteMarkerMap: " << deleteMarkerMapTime.get() * 1000 << "\n";
-  stream << "executeBinaryDependency: " << executeBinaryDependencyTime.get() *
-                                               1000 << "\n";
-  stream << "executeAbstractMemoryDependency: "
+  stream << "\nKLEE: done: ITreeNode method execution times (ms):\n";
+  stream << "KLEE: done:     getInterpolant: " << getInterpolantTime.get() *
+                                                      1000 << "\n";
+  stream << "KLEE: done:     addConstraintTime: " << addConstraintTime.get() *
+                                                         1000 << "\n";
+  stream << "KLEE: done:     splitTime: " << splitTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     makeMarkerMap: " << makeMarkerMapTime.get() * 1000
+         << "\n";
+  stream << "KLEE: done:     deleteMarkerMap: " << deleteMarkerMapTime.get() *
+                                                       1000 << "\n";
+  stream << "KLEE: done:     executeBinaryDependency: "
+         << executeBinaryDependencyTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     executeAbstractMemoryDependency: "
          << executeAbstractMemoryDependencyTime.get() * 1000 << "\n";
-  stream << "executeAbstractDependency: "
+  stream << "KLEE: done:     executeAbstractDependency: "
          << executeAbstractDependencyTime.get() * 1000 << "\n";
-  stream << "bindCallArguments: " << bindCallArgumentsTime.get() * 1000 << "\n";
-  stream << "popAbstractDependencyFrame: "
+  stream << "KLEE: done:     bindCallArguments: "
+         << bindCallArgumentsTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     popAbstractDependencyFrame: "
          << popAbstractDependencyFrameTime.get() * 1000 << "\n";
-  stream << "getLatestCoreExpressions: " << getLatestCoreExpressionsTime.get() *
-                                                1000 << "\n";
-  stream << "getCompositeCoreExpressions: "
+  stream << "KLEE: done:     getLatestCoreExpressions: "
+         << getLatestCoreExpressionsTime.get() * 1000 << "\n";
+  stream << "KLEE: done:     getCompositeCoreExpressions: "
          << getCompositeCoreExpressionsTime.get() * 1000 << "\n";
-  stream << "getLatestInterpolantCoreExpressions: "
+  stream << "KLEE: done:     getLatestInterpolantCoreExpressions: "
          << getLatestCoreExpressionsTime.get() << "\n";
-  stream << "getCompositeInterpolantCoreExpressions: "
+  stream << "KLEE: done:     getCompositeInterpolantCoreExpressions: "
          << getCompositeInterpolantCoreExpressionsTime.get() * 1000 << "\n";
-  stream << "computeInterpolantAllocations: "
+  stream << "KLEE: done:     computeInterpolantAllocations: "
          << computeInterpolantAllocationsTime.get() * 1000 << "\n";
+}
+
+void ITreeNode::dumpTimeStat() {
+  bool useColors = llvm::errs().is_displayed();
+  if (useColors)
+    llvm::errs().changeColor(llvm::raw_ostream::GREEN,
+                             /*bold=*/true,
+                             /*bg=*/false);
+  printTimeStat(llvm::errs());
+  if (useColors)
+    llvm::errs().resetColor();
 }
 
 ITreeNode::ITreeNode(ITreeNode *_parent)

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -317,8 +317,14 @@ public:
 };
 
 class SubsumptionTableEntry {
-  ///@brief Statistics for actual solver call time in subsumption check
+  /// @brief Statistics for actual solver call time in subsumption check
   static TimeStat actualSolverCallTime;
+
+  /// @brief The number of solver calls for subsumption checks
+  static unsigned long checkSolverCount;
+
+  /// @brief The number of failed solver calls for subsumption checks
+  static unsigned long checkSolverFailureCount;
 
   uintptr_t nodeId;
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -57,6 +57,9 @@ struct InterpolationOption {
 
   /// @brief Output the tree tree.dot in .dot file format
   static bool outputTree;
+
+  /// @brief To display running time statistics of interpolation methods
+  static bool timeStat;
 };
 
 /// Storage of search tree for displaying
@@ -374,7 +377,7 @@ public:
 
   void print(llvm::raw_ostream &stream) const;
 
-  static void dumpTimeStat() { printTimeStat(llvm::errs()); }
+  static void dumpTimeStat();
 };
 
 class ITree {
@@ -436,7 +439,7 @@ public:
 
   void dump();
 
-  static void dumpTimeStat() { printTimeStat(llvm::errs()); }
+  static void dumpTimeStat();
 };
 
 class ITreeNode {
@@ -534,7 +537,7 @@ public:
 
   void print(llvm::raw_ostream &stream) const;
 
-  static void dumpTimeStat() { printTimeStat(llvm::errs()); }
+  static void dumpTimeStat();
 
 private:
   ITreeNode(ITreeNode *_parent);

--- a/lib/Solver/Solver.cpp
+++ b/lib/Solver/Solver.cpp
@@ -1128,9 +1128,8 @@ SolverImpl::SolverRunStatus Z3SolverImpl::runAndGetCex(
 
   Z3_solver_assert(builder->ctx, the_solver, Z3_mk_not(builder->ctx, q));
 
-  //   llvm::errs() << "Solving: " << Z3_solver_to_string(builder->ctx,
-  // the_solver)
-  //               << "\n";
+  // llvm::errs() << "Solving: " << Z3_solver_to_string(builder->ctx, the_solver)
+  //              << "\n";
 
   switch (Z3_solver_check(builder->ctx, the_solver)) {
     case Z3_L_TRUE: {


### PR DESCRIPTION
This is so that running time statistics for interpolation methods is only displayed when this option is specified.