### PR TITLE
Faster Subsumption Table Indexing and Simplified Interpolation Statistics

### DIFF
--- a/include/klee/CommandLine.h
+++ b/include/klee/CommandLine.h
@@ -73,7 +73,7 @@ extern llvm::cl::opt<bool> NoInterpolation;
 #ifdef SUPPORT_Z3
 extern llvm::cl::opt<bool> OutputTree;
 
-extern llvm::cl::opt<bool> InterpolationTimeStat;
+extern llvm::cl::opt<bool> InterpolationStat;
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Basic/CmdLineOptions.cpp
+++ b/lib/Basic/CmdLineOptions.cpp
@@ -97,10 +97,10 @@ llvm::cl::opt<bool> OutputTree(
                    "format. At present, this feature is only available when "
                    "Z3 is compiled in and interpolation is enabled."));
 
-llvm::cl::opt<bool> InterpolationTimeStat(
-    "interpolation-time-stat",
+llvm::cl::opt<bool> InterpolationStat(
+    "interpolation-stat",
     llvm::cl::desc(
-        "Displays a summary of execution times of interpolation methods."));
+        "Displays an execution profile of the interpolation routines."));
 #endif
 
 #ifdef SUPPORT_METASMT

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -3761,11 +3761,8 @@ void Executor::runFunctionAsMain(Function *f,
     SearchTree::deallocate();
 
     // Print interpolation time statistics
-    if (InterpolationTimeStat) {
-      SubsumptionTableEntry::dumpTimeStat();
-      ITree::dumpTimeStat();
-      ITreeNode::dumpTimeStat();
-    }
+    if (InterpolationStat)
+      interpTree->dumpInterpolationStat();
 
     delete interpTree;
     interpTree = 0;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -314,8 +314,6 @@ class SubsumptionTableEntry {
   /// @brief The number of failed solver calls for subsumption checks
   static unsigned long checkSolverFailureCount;
 
-  uintptr_t nodeId;
-
   ref<Expr> interpolant;
 
   std::map<llvm::Value *, ref<Expr> > singletonStore;
@@ -360,6 +358,8 @@ class SubsumptionTableEntry {
   static void printTimeStat(llvm::raw_ostream &stream);
 
 public:
+  const uintptr_t nodeId;
+
   SubsumptionTableEntry(ITreeNode *node);
 
   ~SubsumptionTableEntry();
@@ -389,7 +389,7 @@ class ITree {
 
   ITreeNode *currentINode;
 
-  std::vector<SubsumptionTableEntry *> subsumptionTable;
+  std::map<uintptr_t, std::vector<SubsumptionTableEntry *> > subsumptionTable;
 
   void printNode(llvm::raw_ostream &stream, ITreeNode *n, std::string edges);
 
@@ -402,8 +402,6 @@ public:
   ITree(ExecutionState *_root);
 
   ~ITree();
-
-  std::vector<SubsumptionTableEntry *> getStore();
 
   void store(SubsumptionTableEntry *subItem);
 

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -305,6 +305,8 @@ public:
 };
 
 class SubsumptionTableEntry {
+  friend class ITree;
+
   /// @brief Statistics for actual solver call time in subsumption check
   static StatTimer actualSolverCallTimer;
 
@@ -355,7 +357,7 @@ class SubsumptionTableEntry {
   }
 
   /// @brief for printing method running time statistics
-  static void printTimeStat(llvm::raw_ostream &stream);
+  static void printStat(llvm::raw_ostream &stream);
 
 public:
   const uintptr_t nodeId;
@@ -370,7 +372,6 @@ public:
 
   void print(llvm::raw_ostream &stream) const;
 
-  static void dumpTimeStat();
 };
 
 class ITree {
@@ -393,8 +394,11 @@ class ITree {
 
   void printNode(llvm::raw_ostream &stream, ITreeNode *n, std::string edges);
 
-  /// @brief for printing method running time statistics
+  /// @brief Displays method running time statistics
   static void printTimeStat(llvm::raw_ostream &stream);
+
+  /// @brief Displays subsumption table statistics
+  void printTableStat(llvm::raw_ostream &stream);
 
 public:
   ITreeNode *root;
@@ -430,7 +434,8 @@ public:
 
   void dump();
 
-  static void dumpTimeStat();
+  /// @brief Outputs interpolation statistics to standard error.
+  void dumpInterpolationStat();
 };
 
 class ITreeNode {
@@ -527,8 +532,6 @@ public:
   void dump() const;
 
   void print(llvm::raw_ostream &stream) const;
-
-  static void dumpTimeStat();
 
 private:
   ITreeNode(ITreeNode *_parent);

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -27,21 +27,21 @@ class PathCondition;
 class SubsumptionTableEntry;
 
 /// Time records for method running time statistics
-class TimeStat {
+class StatTimer {
   double amount;
   double lastRecorded;
 
 public:
-  TimeStat() : amount(0.0), lastRecorded(0.0) {}
+  StatTimer() : amount(0.0), lastRecorded(0.0) {}
 
-  ~TimeStat() {}
+  ~StatTimer() {}
 
   void start() {
     if (lastRecorded == 0.0)
       lastRecorded = clock();
   }
 
-  void end() {
+  void stop() {
     amount += (clock() - lastRecorded);
     lastRecorded = 0.0;
   }
@@ -306,7 +306,7 @@ public:
 
 class SubsumptionTableEntry {
   /// @brief Statistics for actual solver call time in subsumption check
-  static TimeStat actualSolverCallTime;
+  static StatTimer actualSolverCallTimer;
 
   /// @brief The number of solver calls for subsumption checks
   static unsigned long checkSolverCount;
@@ -378,14 +378,14 @@ class ITree {
   typedef ExprList::iterator iterator;
   typedef ExprList::const_iterator const_iterator;
 
-  static TimeStat setCurrentINodeTime;
-  static TimeStat removeTime;
-  static TimeStat checkCurrentStateSubsumptionTime;
-  static TimeStat markPathConditionTime;
-  static TimeStat splitTime;
-  static TimeStat executeAbstractBinaryDependencyTime;
-  static TimeStat executeAbstractMemoryDependencyTime;
-  static TimeStat executeAbstractDependencyTime;
+  static StatTimer setCurrentINodeTimer;
+  static StatTimer removeTimer;
+  static StatTimer checkCurrentStateSubsumptionTimer;
+  static StatTimer markPathConditionTimer;
+  static StatTimer splitTimer;
+  static StatTimer executeAbstractBinaryDependencyTimer;
+  static StatTimer executeAbstractMemoryDependencyTimer;
+  static StatTimer executeAbstractDependencyTimer;
 
   ITreeNode *currentINode;
 
@@ -440,21 +440,21 @@ class ITreeNode {
 
   friend class ExecutionState;
 
-  static TimeStat getInterpolantTime;
-  static TimeStat addConstraintTime;
-  static TimeStat splitTime;
-  static TimeStat makeMarkerMapTime;
-  static TimeStat deleteMarkerMapTime;
-  static TimeStat executeBinaryDependencyTime;
-  static TimeStat executeAbstractMemoryDependencyTime;
-  static TimeStat executeAbstractDependencyTime;
-  static TimeStat bindCallArgumentsTime;
-  static TimeStat popAbstractDependencyFrameTime;
-  static TimeStat getLatestCoreExpressionsTime;
-  static TimeStat getCompositeCoreExpressionsTime;
-  static TimeStat getLatestInterpolantCoreExpressionsTime;
-  static TimeStat getCompositeInterpolantCoreExpressionsTime;
-  static TimeStat computeInterpolantAllocationsTime;
+  static StatTimer getInterpolantTimer;
+  static StatTimer addConstraintTimer;
+  static StatTimer splitTimer;
+  static StatTimer makeMarkerMapTimer;
+  static StatTimer deleteMarkerMapTimer;
+  static StatTimer executeBinaryDependencyTimer;
+  static StatTimer executeAbstractMemoryDependencyTimer;
+  static StatTimer executeAbstractDependencyTimer;
+  static StatTimer bindCallArgumentsTimer;
+  static StatTimer popAbstractDependencyFrameTimer;
+  static StatTimer getLatestCoreExpressionsTimer;
+  static StatTimer getCompositeCoreExpressionsTimer;
+  static StatTimer getLatestInterpolantCoreExpressionsTimer;
+  static StatTimer getCompositeInterpolantCoreExpressionsTimer;
+  static StatTimer computeInterpolantAllocationsTimer;
 
 private:
   typedef ref<Expr> expression_type;

--- a/tools/klee/main.cpp
+++ b/tools/klee/main.cpp
@@ -1,5 +1,6 @@
 /* -*- mode: c++; c-basic-offset: 2; -*- */
 
+#include "klee/CommandLine.h"
 #include "klee/ExecutionState.h"
 #include "klee/Expr.h"
 #include "klee/Interpreter.h"
@@ -1586,8 +1587,9 @@ int main(int argc, char **argv, char **envp) {
         << handler->getNumPathsExplored() << ", among which\n";
   stats << "KLEE: done:     early-terminating paths (instruction time limit, solver timeout, max-depth reached) = "
         << handler->getEarlyTermination() << "\n";
-  stats << "KLEE: done:     subsumed paths = "
-        << handler->getSubsumptionTermination() << "\n";
+  if (INTERPOLATION_ENABLED)
+    stats << "KLEE: done:     subsumed paths = "
+          << handler->getSubsumptionTermination() << "\n";
   stats << "KLEE: done:     error paths = "
         << handler->getErrorTermination() << "\n";
   stats << "KLEE: done:     program exit paths = "
@@ -1596,8 +1598,9 @@ int main(int argc, char **argv, char **envp) {
         << handler->getNumTestCases() << ", among which\n";
   stats << "KLEE: done:     early-terminating tests (instruction time limit, solver timeout, max-depth reached) = "
         << handler->getEarlyTerminationTest() << "\n";
-  stats << "KLEE: done:     subsumed tests = "
-        << handler->getSubsumptionTerminationTest() << "\n";
+  if (INTERPOLATION_ENABLED)
+    stats << "KLEE: done:     subsumed tests = "
+          << handler->getSubsumptionTerminationTest() << "\n";
   stats << "KLEE: done:     error tests = "
         << handler->getErrorTerminationTest() << "\n";
   stats << "KLEE: done:     program exit tests = "


### PR DESCRIPTION
This PR contains several improvements, namely (slightly) faster subsumption table index that managed to cut off several seconds (on my machine) from the run of KLEE's Tutorial 2 `Regexp.x` example. Also included simplifications on statistics generation and displaying for interpolation functionalities. In addition, `-interpolation-time-stat` has been changed to `-interpolation-stat` as the statistics now doesn't just display timings.