### PR TITLE
Added header comments to Dependency.[h,cpp], ITree.[h,cpp]

### DIFF
--- a/lib/Core/Dependency.cpp
+++ b/lib/Core/Dependency.cpp
@@ -1,3 +1,18 @@
+//===-- Dependency.cpp - Field-insensitive dependency -----------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementation of the flow-insensitive dependency
+/// analysis to compute the allocations upon which the unsatisfiability core
+/// depends, which is used in computing the interpolant.
+///
+//===----------------------------------------------------------------------===//
 
 #include "Dependency.h"
 

--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -1,9 +1,17 @@
-/*
- * ITree.cpp
- *
- *  Created on: Oct 15, 2015
- *      Author: felicia
- */
+//===-- ITree.cpp - Interpolation tree --------------------------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the implementations of the classes for
+/// interpolation and subsumption checks for search-space reduction.
+///
+//===----------------------------------------------------------------------===//
 
 #include "ITree.h"
 #include "Dependency.h"

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -1,9 +1,17 @@
-/*
- * ITree.h
- *
- *  Created on: Oct 15, 2015
- *      Author: felicia
- */
+//===-- ITree.h - Interpolation tree ----------------------------*- C++ -*-===//
+//
+//               The Tracer-X KLEE Symbolic Virtual Machine
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains declarations of the classes that implements the
+/// interpolation and subsumption checks for search-space reduction.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef ITREE_H_
 #define ITREE_H_


### PR DESCRIPTION
Also added detailed comment block for Dependency class for documenting its functionality.

@feliciahalim I updated the old header comments in ITree.[h,cpp]. This means removing `Author: felicia` line from those headers. FYI, some are in the opinion that it is a better practice not to name source files. As you know, there are no author names in KLEE source files. In any case, your contributions are recorded in the commit history anyway.