### PR TITLE
Fixed incorrect recording of incoming block for PHI nodes

### DIFF
--- a/lib/Core/Dependency.h
+++ b/lib/Core/Dependency.h
@@ -572,7 +572,7 @@ class Allocation {
     std::vector<Allocation *> interpolantAllocations;
 
     /// @brief the basic block of the last-executed instruction
-    llvm::BasicBlock *lastBasicBlock;
+    llvm::BasicBlock *incomingBlock;
 
     VersionedValue *getNewVersionedValue(llvm::Value *value,
                                          ref<Expr> valueExpr);
@@ -649,6 +649,10 @@ class Allocation {
     /// @brief Builds dependency graph between memory allocations
     void buildAllocationGraph(AllocationGraph *g, VersionedValue *value) const;
 
+    /// @brief Implements the condition to update incoming basic block for phi
+    /// nodes
+    void updateIncomingBlock(llvm::Instruction *inst);
+
   public:
     Dependency(Dependency *prev);
 
@@ -656,15 +660,10 @@ class Allocation {
 
     Dependency *cdr() const;
 
-    void execute(llvm::Instruction *instr, ref<Expr> valueExpr);
-
-    void executeMemoryOperation(llvm::Instruction *i, ref<Expr> valueExpr,
-                                ref<Expr> address);
-
-    void executeBinary(llvm::Instruction *i, ref<Expr> valueExpr,
-                       ref<Expr> tExpr, ref<Expr> fExpr);
-
     VersionedValue *getLatestValue(llvm::Value *value, ref<Expr> valueExpr);
+
+    /// @brief Abstract dependency state transition with argument(s)
+    void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
 
     std::map<llvm::Value *, ref<Expr> >
     getLatestCoreExpressions(std::vector<const Array *> &replacements,

--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1611,6 +1611,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       if (branches.second)
         transferToBasicBlock(bi->getSuccessor(1), bi->getParent(), *branches.second);
     }
+    if (INTERPOLATION_ENABLED)
+      interpTree->execute(i);
     break;
   }
   case Instruction::Switch: {
@@ -1687,6 +1689,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
         ++bit;
       }
     }
+    if (INTERPOLATION_ENABLED)
+      interpTree->execute(i);
     break;
  }
   case Instruction::Unreachable:
@@ -1703,6 +1707,9 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
     unsigned numArgs = cs.arg_size();
     Value *fp = cs.getCalledValue();
     Function *f = getTargetFunction(fp, state);
+
+    if (INTERPOLATION_ENABLED)
+      interpTree->execute(i);
 
     // Skip debug intrinsics, we can't evaluate their metadata arguments.
     if (f && isDebugIntrinsic(f, kmodule))
@@ -1813,7 +1820,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -1827,7 +1834,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, tExpr, fExpr);
+      interpTree->execute(i, result, tExpr, fExpr);
     break;
   }
 
@@ -1845,7 +1852,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1857,7 +1864,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
  
@@ -1869,7 +1876,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1881,7 +1888,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1893,7 +1900,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1905,7 +1912,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
  
@@ -1917,7 +1924,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1929,7 +1936,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1941,7 +1948,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1953,7 +1960,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1965,7 +1972,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1977,7 +1984,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -1989,7 +1996,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -2087,7 +2094,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
  
@@ -2139,7 +2146,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, base);
+      interpTree->execute(i, base);
     break;
   }
 
@@ -2153,7 +2160,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
   case Instruction::ZExt: {
@@ -2164,7 +2171,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
   case Instruction::SExt: {
@@ -2175,7 +2182,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2188,7 +2195,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   } 
   case Instruction::PtrToInt: {
@@ -2200,7 +2207,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2210,7 +2217,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2237,7 +2244,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -2261,7 +2268,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
  
@@ -2286,7 +2293,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -2311,7 +2318,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -2336,7 +2343,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
 
@@ -2362,7 +2369,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2387,7 +2394,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2413,7 +2420,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2439,7 +2446,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2460,7 +2467,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2481,7 +2488,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
 
@@ -2584,7 +2591,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, left, right);
+      interpTree->execute(i, result, left, right);
     break;
   }
   case Instruction::InsertValue: {
@@ -2615,7 +2622,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractBinaryDependency(i, result, agg, val);
+      interpTree->execute(i, result, agg, val);
     break;
   }
   case Instruction::ExtractValue: {
@@ -2629,7 +2636,7 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
 
     // Update dependency
     if (INTERPOLATION_ENABLED)
-      interpTree->executeAbstractDependency(i, result);
+      interpTree->execute(i, result);
     break;
   }
  
@@ -3277,7 +3284,7 @@ void Executor::executeAlloc(ExecutionState &state,
 
       // Update dependency
       if (INTERPOLATION_ENABLED)
-        interpTree->executeAbstractDependency(target->inst, mo->getBaseExpr());
+        interpTree->execute(target->inst, mo->getBaseExpr());
 
       if (reallocFrom) {
         unsigned count = std::min(reallocFrom->size, os->size);
@@ -3348,7 +3355,7 @@ void Executor::executeAlloc(ExecutionState &state,
 
           // Update dependency
           if (INTERPOLATION_ENABLED)
-            interpTree->executeAbstractDependency(target->inst, result);
+            interpTree->execute(target->inst, result);
         }
         
         if (hugeSize.second) {
@@ -3496,8 +3503,7 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
 
           // Update dependency
           if (INTERPOLATION_ENABLED && target)
-            interpTree->executeAbstractMemoryDependency(target->inst, value,
-                                                        address);
+            interpTree->execute(target->inst, value, address);
         }          
       } else {
         ref<Expr> result = os->read(offset, type);
@@ -3509,8 +3515,7 @@ void Executor::executeMemoryOperation(ExecutionState &state, bool isWrite,
 
         // Update dependency
         if (INTERPOLATION_ENABLED && target)
-          interpTree->executeAbstractMemoryDependency(target->inst, result,
-                                                      address);
+          interpTree->execute(target->inst, result, address);
       }
 
       return;

--- a/lib/Core/ITree.h
+++ b/lib/Core/ITree.h
@@ -392,9 +392,7 @@ class ITree {
   static StatTimer checkCurrentStateSubsumptionTimer;
   static StatTimer markPathConditionTimer;
   static StatTimer splitTimer;
-  static StatTimer executeAbstractBinaryDependencyTimer;
-  static StatTimer executeAbstractMemoryDependencyTimer;
-  static StatTimer executeAbstractDependencyTimer;
+  static StatTimer executeTimer;
 
   ITreeNode *currentINode;
 
@@ -429,14 +427,14 @@ public:
   std::pair<ITreeNode *, ITreeNode *>
   split(ITreeNode *parent, ExecutionState *left, ExecutionState *right);
 
-  void executeAbstractBinaryDependency(llvm::Instruction *i,
-                                       ref<Expr> valueExpr, ref<Expr> tExpr,
-                                       ref<Expr> fExpr);
+  void execute(llvm::Instruction *instr);
 
-  void executeAbstractMemoryDependency(llvm::Instruction *instr,
-                                       ref<Expr> value, ref<Expr> address);
+  void execute(llvm::Instruction *instr, ref<Expr> arg1);
 
-  void executeAbstractDependency(llvm::Instruction *instr, ref<Expr> value);
+  void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2);
+
+  void execute(llvm::Instruction *instr, ref<Expr> arg1, ref<Expr> arg2,
+               ref<Expr> arg3);
 
   void print(llvm::raw_ostream &stream);
 
@@ -456,9 +454,7 @@ class ITreeNode {
   static StatTimer splitTimer;
   static StatTimer makeMarkerMapTimer;
   static StatTimer deleteMarkerMapTimer;
-  static StatTimer executeBinaryDependencyTimer;
-  static StatTimer executeAbstractMemoryDependencyTimer;
-  static StatTimer executeAbstractDependencyTimer;
+  static StatTimer executeTimer;
   static StatTimer bindCallArgumentsTimer;
   static StatTimer popAbstractDependencyFrameTimer;
   static StatTimer getLatestCoreExpressionsTimer;
@@ -495,6 +491,8 @@ private:
   /// @brief for printing method running time statistics
   static void printTimeStat(llvm::raw_ostream &stream);
 
+  void execute(llvm::Instruction *instr, std::vector<ref<Expr> > &args);
+
 public:
   uintptr_t getNodeId();
 
@@ -508,14 +506,6 @@ public:
 
   static void
   deleteMarkerMap(std::map<Expr *, PathConditionMarker *> &markerMap);
-
-  void executeBinaryDependency(llvm::Instruction *i, ref<Expr> valueExpr,
-                               ref<Expr> tExpr, ref<Expr> fExpr);
-
-  void executeAbstractMemoryDependency(llvm::Instruction *instr,
-                                       ref<Expr> value, ref<Expr> address);
-
-  void executeAbstractDependency(llvm::Instruction *instr, ref<Expr> value);
 
   void bindCallArguments(llvm::Instruction *site,
                          std::vector<ref<Expr> > &arguments);


### PR DESCRIPTION
Without this fix, basic/arraysimple2.c and basic/arraysimple3.c in feliciahalim/klee-examples#20 will throw assertion violation from within LLVM. Also cleaned up and simplified the interface of abstract dependency transition implementations in Dependency.[cpp,h]. 