### PR TITLE
Refined Condition for Marking Branch Condition as Core

### DIFF
--- a/lib/Core/Executor.cpp
+++ b/lib/Core/Executor.cpp
@@ -1621,8 +1621,8 @@ void Executor::executeInstruction(ExecutionState &state, KInstruction *ki) {
       // of the solver to decide its satisfiability, and no generation
       // of the unsatisfiability core.
       if (INTERPOLATION_ENABLED &&
-	  (!branches.first || !branches.second))
-        interpTree->execute(i);
+    		  ((!branches.first && branches.second) || (branches.first && !branches.second)))
+    	  interpTree->execute(i);
     }
     break;
   }


### PR DESCRIPTION
@domainexpert  when the branch can only go one way or concrete non-symbolic condition, subsequent data values are actually control-dependent on the condition. So the values in such conditions should be marked as core values to be considered at subsumption checks