### PR TITLE
Quick return in SubsumptionTableEntry::subsumed

### DIFF
--- a/lib/Core/ITree.cpp
+++ b/lib/Core/ITree.cpp
@@ -912,6 +912,9 @@ SubsumptionTableEntry::simplifyArithmeticBody(ref<Expr> existsExpr,
   ref<Expr> fullEqualityConstraint =
       simplifyEqualityExpr(equalityPack, body->getKid(1));
 
+  if (fullEqualityConstraint->isFalse())
+    return fullEqualityConstraint;
+
   // Try to simplify the interpolant. If the resulting simplification
   // was the constant true, then the equality constraints would contain
   // equality with constants only and no equality with shadow (existential)
@@ -1284,6 +1287,11 @@ bool SubsumptionTableEntry::subsumed(TimingSolver *solver,
     // ExprPPrinter::printQuery(llvm::errs(), state.constraints, existsExpr);
     query = simplifyExistsExpr(existsExpr, queryHasNoFreeVariables);
   }
+
+  // If query simplification result was false, we quickly fail without calling
+  // the solver
+  if (query->isFalse())
+    return false;
 
   bool success = false;
 


### PR DESCRIPTION
For the case when the query simplifies to false. This speeds up Tracer-X runs at least for bubble sort (compare `make bubble.klee` and `make bubble.stpklee` in feliciahalim/klee-examples/basic).
